### PR TITLE
resolve stylable to an absolute path

### DIFF
--- a/src/stylable-transform.ts
+++ b/src/stylable-transform.ts
@@ -1,7 +1,7 @@
 const deindent = require('deindent');
 import { StylableResults } from 'stylable';
 
-const runtimePath = 'stylable/runtime';
+const runtimePath = require.resolve('stylable/runtime');
 
 let globalVersion = 0;
 


### PR DESCRIPTION
Hey 👋 

This PR fixes the case when a project runs its tests using the stylable require hook but project doesn't have a direct dependency on stylable

myProject (no stylable) => component library (with stylable)

Thanks
